### PR TITLE
Update GitHub workflows: remove CompatHelper, add Julia dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
⚠️ **Important**: This enables dependabot only for the top-level Julia package. If there are any other sub-packages in subfolders, they will not be tracked by dependabot and may need separate configuration.

CC @Krastanov

## Summary
- Remove CompatHelper workflows (replaced by dependabot)
- Add/update dependabot.yml with Julia package ecosystem  
- Julia dependabot support is now stable and preferred over CompatHelper

## Changes
- Deleted any CompatHelper workflow files from `.github/workflows/`
- Updated/created `.github/dependabot.yml` with Julia package ecosystem configuration
- Set weekly update schedule for Julia dependencies

## Test plan
- [ ] Verify no CompatHelper workflows remain in `.github/workflows/`
- [ ] Confirm dependabot.yml has proper Julia ecosystem configuration
- [ ] Check that dependabot starts working after merge (may take up to 24 hours)

🤖 Generated with [Claude Code](https://claude.ai/code)

---

**Script source**: https://gist.github.com/Krastanov-agent/2b049684a01788458c399e9441bb264a